### PR TITLE
'direction' option

### DIFF
--- a/swipeout.js
+++ b/swipeout.js
@@ -1,6 +1,6 @@
 /*
  * SwipeOut
- * version 0.2.0
+ * version 0.2.1
  * https://github.com/ankane/swipeout
  * Licensed under the MIT license.
  */
@@ -18,6 +18,7 @@ function SwipeOut(listEl, options) {
     hammer = null,
     deleteBtn = document.createElement("div"),
     btnText = options.btnText || "Delete",
+	direction = options.direction || "all",
     touchable = "ontouchstart" in window;
 
   // generic helpers
@@ -125,8 +126,10 @@ function SwipeOut(listEl, options) {
         swiped = true;
         var li = findListItemNode(e.target);
         removeElement(deleteBtn);
-        li.appendChild(deleteBtn);
-        showButton(deleteBtn);
+        if (direction === "all" || e.gesture.direction == direction) {
+        	li.appendChild(deleteBtn);
+        	showButton(deleteBtn);
+        }
       }
     }
   }


### PR DESCRIPTION
Hi,

Currently the library invokes on every swipe/drag event. Including up,down,left and right. In my project the swipeleft event is already used for navigation purposes. And being able to invoke a delete button by dragging up and down just doesn't feel right to me.

So that's where the direction option will be very usefull for me. I can just pass the desired direction and it works :). If nothing set, it has the old behavior.

I have added to the demo an example.
